### PR TITLE
Update from OpenNMT/OpenNMT-tf

### DIFF
--- a/bin/ark_to_records.py
+++ b/bin/ark_to_records.py
@@ -7,6 +7,7 @@ to write aligned source and target data.
 from __future__ import print_function
 
 import argparse
+import io
 import numpy as np
 import tensorflow as tf
 
@@ -68,7 +69,7 @@ def write_text(text, writer):
 def ark_to_records_aligned(ark_filename, text_filename, out_prefix, dtype=np.float32):
   """Converts ARK and text datasets to aligned TFRecords and text datasets."""
   record_writer = tf.python_io.TFRecordWriter(out_prefix + ".records")
-  text_writer = open(out_prefix + ".txt", "w")
+  text_writer = io.open(out_prefix + ".txt", encoding="utf-8", mode="w")
 
   ark_buffer = {}
   text_buffer = {}
@@ -91,7 +92,7 @@ def ark_to_records_aligned(ark_filename, text_filename, out_prefix, dtype=np.flo
 
     return None, None
 
-  with open(ark_filename) as ark_file, open(text_filename) as text_file:
+  with io.open(ark_filename, encoding="utf-8") as ark_file, open(text_filename, encoding="utf-8") as text_file: #pylint: disable=line-too-long
     while True:
       ark_idx, vector = consume_next_vector(ark_file, dtype=dtype)
       text_idx, text = consume_next_text(text_file)
@@ -136,7 +137,7 @@ def ark_to_records(ark_filename, out_prefix, dtype=np.float32):
   record_writer = tf.python_io.TFRecordWriter(out_prefix + ".records")
   count = 0
 
-  with open(ark_filename) as ark_file:
+  with io.open(ark_filename, encoding="utf-8") as ark_file:
     while True:
       ark_idx, vector = consume_next_vector(ark_file, dtype=dtype)
       if not ark_idx:

--- a/opennmt/config.py
+++ b/opennmt/config.py
@@ -2,6 +2,7 @@
 
 from importlib import import_module
 
+import io
 import os
 import pickle
 import sys
@@ -80,7 +81,7 @@ def load_config(config_paths, config=None):
     config = {}
 
   for config_path in config_paths:
-    with open(config_path) as config_file:
+    with io.open(config_path, encoding="utf-8") as config_file:
       subconfig = yaml.load(config_file.read())
 
       # Add or update section in main configuration.

--- a/opennmt/inputters/text_inputter.py
+++ b/opennmt/inputters/text_inputter.py
@@ -2,6 +2,7 @@
 
 import abc
 import collections
+import io
 import os
 import shutil
 import six
@@ -39,7 +40,7 @@ def visualize_embeddings(log_dir, embedding_var, vocabulary_file, num_oov_bucket
   shutil.copy(vocabulary_file, destination)
 
   # Append <unk> tokens.
-  with open(destination, "a") as vocab:
+  with io.open(destination, encoding="utf-8", mode="a") as vocab:
     if num_oov_buckets == 1:
       vocab.write("<unk>\n")
     else:
@@ -51,7 +52,7 @@ def visualize_embeddings(log_dir, embedding_var, vocabulary_file, num_oov_bucket
   # If the projector file exists, load it.
   target = os.path.join(log_dir, "projector_config.pbtxt")
   if os.path.exists(target):
-    with open(target) as target_file:
+    with io.open(target, encoding="utf-8") as target_file:
       text_format.Merge(target_file.read(), config)
 
   # If this embedding is already registered, just update the metadata path.
@@ -122,7 +123,7 @@ def load_pretrained_embeddings(embedding_file,
   """
   # Map words to ids from the vocabulary.
   word_to_id = collections.defaultdict(list)
-  with open(vocabulary_file) as vocabulary:
+  with io.open(vocabulary_file, encoding="utf-8") as vocabulary:
     count = 0
     for word in vocabulary:
       word = word.strip()
@@ -132,7 +133,7 @@ def load_pretrained_embeddings(embedding_file,
       count += 1
 
   # Fill pretrained embedding matrix.
-  with open(embedding_file) as embedding:
+  with io.open(embedding_file, encoding="utf-8") as embedding:
     pretrained = None
 
     if with_header:

--- a/opennmt/runner.py
+++ b/opennmt/runner.py
@@ -1,5 +1,6 @@
 """Main library entrypoint."""
 
+import io
 import os
 import sys
 import random
@@ -175,7 +176,7 @@ class Runner(object):
         prefetch_buffer_size=self._config["infer"].get("prefetch_buffer_size", 1))
 
     if predictions_file:
-      stream = open(predictions_file, "w")
+      stream = io.open(predictions_file, encoding="utf-8", mode="w")
     else:
       stream = sys.stdout
 

--- a/opennmt/tests/config_test.py
+++ b/opennmt/tests/config_test.py
@@ -1,3 +1,4 @@
+import io
 import os
 import yaml
 
@@ -14,10 +15,16 @@ class ConfigTest(tf.test.TestCase):
     config_file_1 = os.path.join(self.get_temp_dir(), "config1.yml")
     config_file_2 = os.path.join(self.get_temp_dir(), "config2.yml")
 
-    with open(config_file_1, "w") as config_file:
-      config_file.write(yaml.dump(config1))
-    with open(config_file_2, "w") as config_file:
-      config_file.write(yaml.dump(config2))
+    with io.open(config_file_1, encoding="utf-8", mode="w") as config_file:
+      try:
+        config_file.write(yaml.dump(config1))
+      except TypeError:
+        config_file.write(unicode(yaml.dump(config1)))
+    with io.open(config_file_2, encoding="utf-8", mode="w") as config_file:
+      try:
+        config_file.write(yaml.dump(config2))
+      except TypeError:
+        config_file.write(unicode(yaml.dump(config2)))
 
     loaded_config = config.load_config([config_file_1, config_file_2])
 

--- a/opennmt/tests/inputter_test.py
+++ b/opennmt/tests/inputter_test.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import io
 import os
 import six
 
@@ -40,15 +41,15 @@ class InputterTest(tf.test.TestCase):
     embedding_file = os.path.join(self.get_temp_dir(), "embedding.txt")
     vocab_file = os.path.join(self.get_temp_dir(), "vocab.txt")
 
-    with open(embedding_file, "w") as embedding:
-      embedding.write("toto 1 1\n"
-                      "titi 2 2\n"
-                      "tata 3 3\n")
-    with open(vocab_file, "w") as vocab:
-      vocab.write("Toto\n"
-                  "tOTO\n"
-                  "tata\n"
-                  "tete\n")
+    with io.open(embedding_file, encoding="utf-8", mode="w") as embedding:
+      embedding.write(u"toto 1 1\n"
+                      u"titi 2 2\n"
+                      u"tata 3 3\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"Toto\n"
+                  u"tOTO\n"
+                  u"tata\n"
+                  u"tete\n")
 
     embeddings = text_inputter.load_pretrained_embeddings(
         embedding_file,
@@ -74,16 +75,16 @@ class InputterTest(tf.test.TestCase):
     embedding_file = os.path.join(self.get_temp_dir(), "embedding.txt")
     vocab_file = os.path.join(self.get_temp_dir(), "vocab.txt")
 
-    with open(embedding_file, "w") as embedding:
-      embedding.write("3 2\n"
-                      "toto 1 1\n"
-                      "titi 2 2\n"
-                      "tata 3 3\n")
-    with open(vocab_file, "w") as vocab:
-      vocab.write("Toto\n"
-                  "tOTO\n"
-                  "tata\n"
-                  "tete\n")
+    with io.open(embedding_file, encoding="utf-8", mode="w") as embedding:
+      embedding.write(u"3 2\n"
+                      u"toto 1 1\n"
+                      u"titi 2 2\n"
+                      u"tata 3 3\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"Toto\n"
+                  u"tOTO\n"
+                  u"tata\n"
+                  u"tete\n")
 
     embeddings = text_inputter.load_pretrained_embeddings(
         embedding_file,
@@ -123,13 +124,13 @@ class InputterTest(tf.test.TestCase):
     vocab_file = os.path.join(self.get_temp_dir(), "vocab.txt")
     data_file = os.path.join(self.get_temp_dir(), "data.txt")
 
-    with open(vocab_file, "w") as vocab:
-      vocab.write("the\n"
-                  "world\n"
-                  "hello\n"
-                  "toto\n")
-    with open(data_file, "w") as data:
-      data.write("hello world !\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"the\n"
+                  u"world\n"
+                  u"hello\n"
+                  u"toto\n")
+    with io.open(data_file, encoding="utf-8", mode="w") as data:
+      data.write(u"hello world !\n")
 
     embedder = text_inputter.WordEmbedder("vocabulary_file", embedding_size=10)
     features, transformed = self._makeDataset(
@@ -152,14 +153,14 @@ class InputterTest(tf.test.TestCase):
     vocab_file = os.path.join(self.get_temp_dir(), "vocab.txt")
     data_file = os.path.join(self.get_temp_dir(), "data.txt")
 
-    with open(vocab_file, "w") as vocab:
-      vocab.write("h\n"
-                  "e\n"
-                  "l\n"
-                  "w\n"
-                  "o\n")
-    with open(data_file, "w") as data:
-      data.write("hello world !\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"h\n"
+                  u"e\n"
+                  u"l\n"
+                  u"w\n"
+                  u"o\n")
+    with io.open(data_file, encoding="utf-8", mode="w") as data:
+      data.write(u"hello world !\n")
 
     embedder = text_inputter.CharConvEmbedder("vocabulary_file", 10, 5)
     features, transformed = self._makeDataset(
@@ -184,13 +185,13 @@ class InputterTest(tf.test.TestCase):
     vocab_file = os.path.join(self.get_temp_dir(), "vocab.txt")
     data_file = os.path.join(self.get_temp_dir(), "data.txt")
 
-    with open(vocab_file, "w") as vocab:
-      vocab.write("the\n"
-                  "world\n"
-                  "hello\n"
-                  "toto\n")
-    with open(data_file, "w") as data:
-      data.write("hello world !\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"the\n"
+                  u"world\n"
+                  u"hello\n"
+                  u"toto\n")
+    with io.open(data_file, encoding="utf-8", mode="w") as data:
+      data.write(u"hello world !\n")
 
     data_files = [data_file, data_file]
 
@@ -223,19 +224,19 @@ class InputterTest(tf.test.TestCase):
     vocab_alt_file = os.path.join(self.get_temp_dir(), "vocab_alt.txt")
     data_file = os.path.join(self.get_temp_dir(), "data.txt")
 
-    with open(vocab_file, "w") as vocab:
-      vocab.write("the\n"
-                  "world\n"
-                  "hello\n"
-                  "toto\n")
-    with open(vocab_alt_file, "w") as vocab_alt:
-      vocab_alt.write("h\n"
-                      "e\n"
-                      "l\n"
-                      "w\n"
-                      "o\n")
-    with open(data_file, "w") as data:
-      data.write("hello world !\n")
+    with io.open(vocab_file, encoding="utf-8", mode="w") as vocab:
+      vocab.write(u"the\n"
+                  u"world\n"
+                  u"hello\n"
+                  u"toto\n")
+    with io.open(vocab_alt_file, encoding="utf-8", mode="w") as vocab_alt:
+      vocab_alt.write(u"h\n"
+                      u"e\n"
+                      u"l\n"
+                      u"w\n"
+                      u"o\n")
+    with io.open(data_file, encoding="utf-8", mode="w") as data:
+      data.write(u"hello world !\n")
 
     mixed_inputter = inputter.MixedInputter([
         text_inputter.WordEmbedder("vocabulary_file_1", embedding_size=10),

--- a/opennmt/tokenizers/tokenizer.py
+++ b/opennmt/tokenizers/tokenizer.py
@@ -2,6 +2,7 @@
 
 """Define base tokenizers."""
 
+import io
 import sys
 import os
 import abc
@@ -27,7 +28,7 @@ class Tokenizer(object):
     self._config = {}
     if configuration_file_or_key is not None and os.path.isfile(configuration_file_or_key):
       configuration_file = configuration_file_or_key
-      with open(configuration_file) as conf_file:
+      with io.open(configuration_file, encoding="utf-8") as conf_file:
         self._config = yaml.load(conf_file)
       self._configuration_file_key = None
     else:
@@ -48,7 +49,7 @@ class Tokenizer(object):
     """
     if self._configuration_file_key is not None:
       configuration_file = metadata[self._configuration_file_key]
-      with open(configuration_file) as conf_file:
+      with io.open(configuration_file, encoding="utf-8") as conf_file:
         self._config = yaml.load(conf_file)
 
   def tokenize_stream(self, input_stream=sys.stdin, output_stream=sys.stdout, delimiter=" "):

--- a/opennmt/utils/evaluator.py
+++ b/opennmt/utils/evaluator.py
@@ -3,6 +3,7 @@
 import subprocess
 
 import abc
+import io
 import re
 import os
 import six
@@ -78,7 +79,7 @@ class BLEUEvaluator(ExternalEvaluator):
       tf.logging.warning("%s", str(e))
       return None
     try:
-      with open(predictions_path, "r") as predictions_file:
+      with io.open(predictions_path, encoding="utf-8", mode="r") as predictions_file:
         bleu_out = subprocess.check_output(
             [os.path.join(third_party_dir, bleu_script), labels_file],
             stdin=predictions_file,

--- a/opennmt/utils/hooks.py
+++ b/opennmt/utils/hooks.py
@@ -1,6 +1,7 @@
 """Custom hooks."""
 
 from __future__ import print_function
+import io
 
 import tensorflow as tf
 
@@ -129,7 +130,7 @@ class SaveEvaluationPredictionHook(tf.train.SessionRunHook):
   def after_run(self, run_context, run_values):  # pylint: disable=unused-argument
     predictions, self._current_step = run_values.results
     self._output_path = "{}.{}".format(self._output_file, self._current_step)
-    with open(self._output_path, "a") as output_file:
+    with io.open(self._output_path, encoding="utf-8", mode="a") as output_file:
       for prediction in misc.extract_batches(predictions):
         self._model.print_prediction(prediction, stream=output_file)
 


### PR DESCRIPTION
* changed all instances of open to io.open with encoding set to utf-8, unless byte mode is set

* fixed import io location in hooks.py; change open to io.open in runner.py

* try/except around writing yaml.dump to catch str/unicode diff between python 2.7 and 3.x;  make strings unicode in tests for compatibility

* fixed typo in which config file to write

* disable line-too-long for one line in ark_to_records